### PR TITLE
[#70368312] Adds Timeout option to the RouteMaster client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ require 'routemaster/client'
 client = RoutemasterClient.new(url: 'https://bus.example.com', uuid: 'john-doe')
 ```
 
+You can also specify a timeout value in seconds if you like with the ```timeout``` option.
+
+```ruby
+RoutemasterClient.new(url: 'https://bus.example.com', uuid: 'john-doe', timeout: 2)
+```
+
 
 **Push** an event about an entity in the topic `widgets` with a callback URL:
 
@@ -83,7 +89,7 @@ client.monitor_topics
 #=> [ { name: 'widgets', publisher: 'john-doe', events: 12589 }, ...]
 
 client.monitor_subscriptions
-#=> [ { 
+#=> [ {
 #     subscriber: 'bob',
 #     callback:   'https://app.example.com/events',
 #     topics:     ['widgets', 'kitten'],

--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -9,8 +9,11 @@ module Routemaster
     def initialize(options = {})
       @_url = _assert_valid_url(options[:url])
       @_uuid = options[:uuid]
+      @_timeout = options.fetch(:timeout, 1)
+
       _assert (options[:uuid] =~ /^[a-z0-9_-]{1,64}$/), 'uuid should be alpha'
-      
+      _assert_valid_timeout(@_timeout)
+
       _conn.get('/pulse').tap do |response|
         raise 'cannot connect to bus' unless response.success?
       end
@@ -51,7 +54,7 @@ module Routemaster
       end
       # $stderr.puts response.status
       unless response.success?
-        raise "subscription rejected"
+        raise 'subscription rejected'
       end
     end
 
@@ -95,6 +98,7 @@ module Routemaster
       @_conn ||= Faraday.new(@_url) do |f|
         f.use Faraday::Request::BasicAuthentication, @_uuid, 'x'
         f.adapter :net_http_persistent
+        f.options.timeout = @_timeout
       end
     end
   end


### PR DESCRIPTION
> We would need to add a timeout option to the RouteMaster client library to make sure we don't make the user wait for a long time in case the RouteMaster is not functioning properly.
