### PR TITLE
Platform: Fix faraday [#75574188]

### DIFF
--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -109,7 +109,7 @@ module Routemaster
       @_conn ||= Faraday.new(@_url) do |f|
         f.use Faraday::Request::BasicAuthentication, @_uuid, 'x'
         f.adapter :net_http_persistent
-        f.options.timeout = @_timeout
+        f.options[:timeout] = @_timeout
       end
     end
   end


### PR DESCRIPTION
Pivotal tracker story [#75574188](https://www.pivotaltracker.com/story/show/75574188) in project _Platform_:

> Based on the recommendation in https://github.com/HouseTrip/routemaster_client/issues/12
> 
> We should test the routemaster-client with different versions of faraday to make sure it works.
> 
> Update the bundle on the property_search and affiliate_app
### News update

The change is actually not breaking, it was just that locally I was using the newer Faraday version and the newer version syntax, which is not supported by the older version. Fortunately, the vice-versa is true (the older syntax is supported by the newer Faraday version)
