### PR TITLE
Platform: Implement #monitor_topics on routemaster_client [#86131554]

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ gem](https://github.com/krisleech/wisper#wisper).
 
 ```ruby
 client.monitor_topics
-#=> [ { name: 'widgets', publisher: 'demo', events: 12589 }, ...]
+#=> [ #<Routemaster::Topic:XXXX @name="widgets", @publisher="demo", @events=12589>, ...]
 
 client.monitor_subscriptions
 #=> [ {

--- a/routemaster/topic.rb
+++ b/routemaster/topic.rb
@@ -1,0 +1,17 @@
+module Routemaster
+  class Topic
+
+    attr_reader :name, :publisher, :events
+
+    def initialize(options)
+      @name      = options.fetch('name')
+      @publisher = options.fetch('publisher')
+      @events    = options.fetch('events')
+    end
+
+    def attributes
+      { name: @name, publisher: @publisher, events: @events }
+    end
+
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'routemaster/client'
+require 'routemaster/topic'
 require 'webmock/rspec'
 
 describe Routemaster::Client do
@@ -208,7 +209,31 @@ describe Routemaster::Client do
   end
 
   describe '#monitor_topics' do
-    it 'passes'
+
+    let(:perform) { subject.monitor_topics }
+    let(:expected_result) do
+      [
+        {
+          name: 'widgets',
+          publisher: 'demo',
+          events: 12589
+        }
+      ]
+    end
+
+    before do
+      @stub = stub_request(
+        :get, %r{^https://#{options[:uuid]}:x@bus.example.com/topics$}
+      ).with { |r|
+        r.headers['Content-Type'] == 'application/json'
+      }.to_return {
+        { status: 200, body: expected_result.to_json }
+      }
+    end
+
+    it 'expects a collection of topics' do
+      expect(perform.map(&:attributes)).to eql(expected_result)
+    end
   end
 
   describe '#monitor_subscriptions' do

--- a/spec/topic_spec.rb
+++ b/spec/topic_spec.rb
@@ -1,0 +1,36 @@
+require 'routemaster/topic'
+
+describe Routemaster::Topic do
+
+  let(:name)      { 'widgets' }
+  let(:publisher) { 'demo' }
+  let(:events)    { 0 }
+
+  subject do
+    described_class.new({
+      "name"      => name,
+      "publisher" => publisher,
+      "events"    => events
+    })
+  end
+
+  describe '#initialize' do
+
+    it "creates an instance of #{described_class}" do
+      expect(subject).to be_an_instance_of(described_class)
+    end
+
+  end
+
+  describe '#attributes' do
+
+    it "returns an hash with all attributes" do
+      expect(subject.attributes).to eql({
+        name: name,
+        publisher: publisher,
+        events: events
+      })
+    end
+
+  end
+end


### PR DESCRIPTION
Pivotal tracker story [#86131554](https://www.pivotaltracker.com/story/show/86131554) in project *Platform*:

> ## Why
> Routemaster has an implementation for monitoring the topics, in other words, allows to get the list of current topics and their respective publishers. However `routemaster-client` does not support this. 
> 
> ## What
> Enable `routemaster-client` to use `GET /topics` from routemaster.
> 
> ## Testing
> Test suite is green